### PR TITLE
IBV flow requires destination MAC: implement fill_if_mac(st->buf["BINDHOST"], dst_mac)

### DIFF
--- a/src/hpguppi_atasnap_voltage_thread.c
+++ b/src/hpguppi_atasnap_voltage_thread.c
@@ -32,9 +32,6 @@
 #include <sys/time.h>
 #include <sys/resource.h>
 
-#include <net/if.h>
-#include <sys/ioctl.h>
-
 #include "hashpipe.h"
 #include "hpguppi_databuf.h"
 #include "hpguppi_time.h"
@@ -463,29 +460,6 @@ enum run_states check_start_stop(hashpipe_status_t *st, uint64_t pktidx)
   return retval;
 }
 
-void fill_if_mac(char *if_name, unsigned char *dst_mac){
-	//https://www.stev.org/post/clinuxgetmacaddressfrominterface
-	int sock = socket(PF_INET, SOCK_DGRAM, 0);
-	struct ifreq req;
-	int i = 0;
-
-	if (sock < 0) {
-		perror("socket");
-		exit(EXIT_FAILURE);
-	}
-
-	memset(&req, 0, sizeof(req));
-  strncpy(req.ifr_name, if_name, IF_NAMESIZE - 1);
-
-	if (ioctl(sock, SIOCGIFHWADDR, &req) < 0) {
-		perror("ioctl");
-		exit(EXIT_FAILURE);
-	}
-
-	for(i=0;i<6;i++)
-		dst_mac[i] = req.ifr_hwaddr.sa_data[i];
-}
-
 // This thread's init() function, if provided, is called by the Hashpipe
 // framework at startup to allow the thread to perform initialization tasks
 // such as setting up network connections or GPU devices.
@@ -610,9 +584,6 @@ int debug_i=0, debug_j=0;
   char dest_ip_stream_str[80] = {};
   char dest_ip_stream_str_new[80] = {};
   char * pchar;
-  // Host's Interface and MAC
-  char host_if_str[IF_NAMESIZE] = {};
-  uint8_t dest_mac[6];
   // Numeric form of dest_ip
   struct in_addr dest_ip;
   int dest_idx;
@@ -635,15 +606,8 @@ int debug_i=0, debug_j=0;
     hgetu4(st->buf, "BINDPORT", &port);
     // Store bind port in status buffer (in case it was not there before).
     hputu4(st->buf, "BINDPORT", port);
-    // Get Bind Host Interface
-    hgets(st->buf, "BINDHOST", sizeof (host_if_str), host_if_str);
   }
   hashpipe_status_unlock_safe(st);
-
-  // Capture Interface MAC
-  fill_if_mac(host_if_str, dest_mac);
-  hashpipe_info(thread_name, "MAC of interface %s is %.2X:%.2X:%.2X:%.2X:%.2X:%.2X",
-                host_if_str, dest_mac[0], dest_mac[1], dest_mac[2], dest_mac[3], dest_mac[4], dest_mac[5]);
 
   // Make sure we got a non-zero max_flows
   if(max_flows == 0) {
@@ -992,8 +956,8 @@ int debug_i=0, debug_j=0;
                 for(dest_idx=0; dest_idx < nstreams; dest_idx++) {
                   errno = 0;
                   if(hpguppi_ibvpkt_flow(dbin, dest_idx, IBV_FLOW_SPEC_UDP,
-                        //hibv_ctx->mac, NULL, 0, 0,
-                        dest_mac, NULL, 0, 0,
+                        // hibv_ctx->mac, NULL, 0, 0,
+                        NULL, NULL, 0, 0,
                         0, ntohl(dest_ip.s_addr)+dest_idx, 0, port))
                   {
                     hashpipe_error(thread_name, "hashpipe_ibv_flow error");

--- a/src/hpguppi_atasnap_voltage_thread.c
+++ b/src/hpguppi_atasnap_voltage_thread.c
@@ -960,6 +960,9 @@ int debug_i=0, debug_j=0;
                         0, ntohl(dest_ip.s_addr)+dest_idx, 0, port))
                   {
                     hashpipe_error(thread_name, "hashpipe_ibv_flow error");
+                    hashpipe_error(thread_name, "%08x %d, destid: %d,"
+                        "nstreams: %d", ntohl(dest_ip.s_addr)+dest_idx, port, 
+                        dest_idx, nstreams);
                     break;
                   }
                 }

--- a/src/hpguppi_atasnap_voltage_thread.c
+++ b/src/hpguppi_atasnap_voltage_thread.c
@@ -954,9 +954,8 @@ int debug_i=0, debug_j=0;
                     dest_ip_stream_str_new, pchar ? pchar+1 : "0");
                 hashpipe_info(thread_name, "adding %d flows", nstreams);
                 for(dest_idx=0; dest_idx < nstreams; dest_idx++) {
-                  errno = 0;
                   if(hpguppi_ibvpkt_flow(dbin, dest_idx, IBV_FLOW_SPEC_UDP,
-                        // hibv_ctx->mac, NULL, 0, 0,
+                        //hibv_ctx->mac, NULL, 0, 0,
                         NULL, NULL, 0, 0,
                         0, ntohl(dest_ip.s_addr)+dest_idx, 0, port))
                   {

--- a/src/hpguppi_ibverbs_pkt_thread.c
+++ b/src/hpguppi_ibverbs_pkt_thread.c
@@ -313,10 +313,15 @@ hpguppi_ibvpkt_flow(
     uint16_t  src_port,   uint16_t  dst_port)
 {
   struct hashpipe_ibv_context * hibv_ctx = hashpipe_ibv_context_ptr(db);
+  
+  if(!dst_mac)
+    fprintf(stderr, "Destination MAC cannot be NULL. "// causes EINVAL [Invalid Argument]
+            "Providing hibv_ctx->mac: %.2X:%.2X:%.2X:%.2X:%.2X:%.2X\n",
+            hibv_ctx->mac[0], hibv_ctx->mac[1], hibv_ctx->mac[2], hibv_ctx->mac[3], hibv_ctx->mac[4], hibv_ctx->mac[5]);
 
   return hashpipe_ibv_flow(hibv_ctx,
     flow_idx,   flow_type,
-    dst_mac,    src_mac,
+    (dst_mac ? dst_mac : hibv_ctx->mac),    src_mac,
     ether_type, vlan_tag,
     src_ip,     dst_ip,
     src_port,   dst_port);


### PR DESCRIPTION
Part of the solution with the implementation at SETI ATA is that a destination MAC is required to form a valid IBV flow specification.
This resolves the EINVAL [Invalid argument] resulting from hpguppi_ibvpkt_flow -> [hashpipe/src/hashpipe_ibverbs:hashpipe_ibv_flow()](https://github.com/realtimeradio/hashpipe/blob/ibverbs-branch/src/hashpipe_ibverbs.c#L947 -> [infiniband/ibv_create_flow](https://github.com/realtimeradio/hashpipe/blob/ibverbs-branch/src/hashpipe_ibverbs.c#L1110).

The MAC of the BINDHOST interface is retrieved via the added function `fill_if_mac()`;